### PR TITLE
Enforce object type for options params

### DIFF
--- a/Tests/FactoryTest.php
+++ b/Tests/FactoryTest.php
@@ -32,6 +32,19 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Tests the getHttp method to ensure only arrays or ArrayAccess objects are allowed
+	 *
+	 * @return  void
+	 *
+	 * @covers             Joomla\Http\HttpFactory::getHttp
+	 * @expectedException  \InvalidArgumentException
+	 */
+	public function testGetHttpDisallowsNonArrayObjects()
+	{
+		HttpFactory::getHttp(new \stdClass);
+	}
+
+	/**
 	 * Tests the getHttp method.
 	 *
 	 * @return  void
@@ -79,6 +92,19 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 			HttpFactory::getAvailableDriver(array(), array('DummyTransport')),
 			'Passing an empty array should return false due to there being no adapters to test'
 		);
+	}
+
+	/**
+	 * Tests the getAvailableDriver method to ensure only arrays or ArrayAccess objects are allowed
+	 *
+	 * @return  void
+	 *
+	 * @covers             Joomla\Http\HttpFactory::getAvailableDriver
+	 * @expectedException  \InvalidArgumentException
+	 */
+	public function testGetAvailableDriverDisallowsNonArrayObjects()
+	{
+		HttpFactory::getAvailableDriver(new \stdClass);
 	}
 
 	/**

--- a/Tests/HttpTest.php
+++ b/Tests/HttpTest.php
@@ -61,6 +61,18 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Tests the constructor to ensure only arrays or ArrayAccess objects are allowed
+	 *
+	 * @return  void
+	 *
+	 * @expectedException  \InvalidArgumentException
+	 */
+	public function testConstructorDisallowsNonArrayObjects()
+	{
+		new Http(new \stdClass);
+	}
+
+	/**
 	 * Tests the getOption method
 	 *
 	 * @return  void

--- a/Tests/TransportTest.php
+++ b/Tests/TransportTest.php
@@ -70,6 +70,21 @@ class TransportTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Tests the transport constructor to ensure only arrays and ArrayAccess objects are allowed
+	 *
+	 * @param   string  $transportClass  The transport class to test
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider       transportProvider
+	 * @expectedException  \InvalidArgumentException
+	 */
+	public function testConstructorWithBadDataObject($transportClass)
+	{
+		new $transportClass(new \stdClass);
+	}
+
+	/**
 	 * Tests the request method with a get request
 	 *
 	 * @param   string  $transportClass  The transport class to test

--- a/src/Http.php
+++ b/src/Http.php
@@ -18,13 +18,17 @@ use Joomla\Uri\Uri;
 class Http
 {
 	/**
-	 * @var    array  Options for the HTTP client.
+	 * Options for the HTTP client.
+	 *
+	 * @var    array|\ArrayAccess
 	 * @since  1.0
 	 */
 	protected $options;
 
 	/**
-	 * @var    TransportInterface  The HTTP transport object to use in sending HTTP requests.
+	 * The HTTP transport object to use in sending HTTP requests.
+	 *
+	 * @var    TransportInterface
 	 * @since  1.0
 	 */
 	protected $transport;
@@ -32,7 +36,7 @@ class Http
 	/**
 	 * Constructor.
 	 *
-	 * @param   array               $options    Client options array. If the registry contains any headers.* elements,
+	 * @param   array|\ArrayAccess  $options    Client options array. If the registry contains any headers.* elements,
 	 *                                          these will be added to the request headers.
 	 * @param   TransportInterface  $transport  The HTTP transport object.
 	 *
@@ -41,7 +45,14 @@ class Http
 	 */
 	public function __construct($options = array(), TransportInterface $transport = null)
 	{
-		$this->options   = $options;
+		if (!is_array($options) && !($options instanceof \ArrayAccess))
+		{
+			throw new \InvalidArgumentException(
+				'The options param must be an array or implement the ArrayAccess interface.'
+			);
+		}
+
+		$this->options = $options;
 
 		if (!isset($transport))
 		{

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -55,7 +55,7 @@ class HttpFactory
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
 	 */
-	public static function getAvailableDriver($options, $default = null)
+	public static function getAvailableDriver($options = array(), $default = null)
 	{
 		if (!is_array($options) && !($options instanceof \ArrayAccess))
 		{

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -48,7 +48,7 @@ class HttpFactory
 	 * Finds an available TransportInterface object for communication
 	 *
 	 * @param   array|\ArrayAccess  $options  Options for creating TransportInterface object
-	 * @param   mixed               $default  Adapter (string) or queue of adapters (array) to use
+	 * @param   array|string        $default  Adapter (string) or queue of adapters (array) to use
 	 *
 	 * @return  TransportInterface|boolean  Interface sub-class or boolean false if no adapters are available
 	 *

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -16,19 +16,26 @@ namespace Joomla\Http;
 class HttpFactory
 {
 	/**
-	 * Method to receive Http instance.
+	 * Method to create an Http instance.
 	 *
-	 * @param   array  $options   Client options array.
-	 * @param   mixed  $adapters  Adapter (string) or queue of adapters (array) to use for communication.
+	 * @param   array|\ArrayAccess  $options   Client options array.
+	 * @param   array|string        $adapters  Adapter (string) or queue of adapters (array) to use for communication.
 	 *
-	 * @return  Http  Joomla Http class
-	 *
-	 * @throws  \RuntimeException
+	 * @return  Http
 	 *
 	 * @since   1.0
+	 * @throws  \InvalidArgumentException
+	 * @throws  \RuntimeException
 	 */
 	public static function getHttp($options = array(), $adapters = null)
 	{
+		if (!is_array($options) && !($options instanceof \ArrayAccess))
+		{
+			throw new \InvalidArgumentException(
+				'The options param must be an array or implement the ArrayAccess interface.'
+			);
+		}
+
 		if (!$driver = self::getAvailableDriver($options, $adapters))
 		{
 			throw new \RuntimeException('No transport driver available.');
@@ -38,17 +45,25 @@ class HttpFactory
 	}
 
 	/**
-	 * Finds an available http transport object for communication
+	 * Finds an available TransportInterface object for communication
 	 *
-	 * @param   array  $options  Option for creating http transport object
-	 * @param   mixed  $default  Adapter (string) or queue of adapters (array) to use
+	 * @param   array|\ArrayAccess  $options  Options for creating TransportInterface object
+	 * @param   mixed               $default  Adapter (string) or queue of adapters (array) to use
 	 *
 	 * @return  TransportInterface|boolean  Interface sub-class or boolean false if no adapters are available
 	 *
 	 * @since   1.0
+	 * @throws  \InvalidArgumentException
 	 */
 	public static function getAvailableDriver($options, $default = null)
 	{
+		if (!is_array($options) && !($options instanceof \ArrayAccess))
+		{
+			throw new \InvalidArgumentException(
+				'The options param must be an array or implement the ArrayAccess interface.'
+			);
+		}
+
 		if (is_null($default))
 		{
 			$availableAdapters = self::getHttpTransports();
@@ -83,7 +98,7 @@ class HttpFactory
 	}
 
 	/**
-	 * Get the http transport handlers
+	 * Get the HTTP transport handlers
 	 *
 	 * @return  array  An array of available transport handlers
 	 *

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -20,7 +20,9 @@ use Joomla\Uri\UriInterface;
 class Curl implements TransportInterface
 {
 	/**
-	 * @var    array  The client options.
+	 * The client options.
+	 *
+	 * @var    array|\ArrayAccess
 	 * @since  1.0
 	 */
 	protected $options;
@@ -28,10 +30,11 @@ class Curl implements TransportInterface
 	/**
 	 * Constructor. CURLOPT_FOLLOWLOCATION must be disabled when open_basedir or safe_mode are enabled.
 	 *
-	 * @param   array  $options  Client options array.
+	 * @param   array|\ArrayAccess  $options  Client options array.
 	 *
 	 * @see     http://www.php.net/manual/en/function.curl-setopt.php
 	 * @since   1.0
+	 * @throws  \InvalidArgumentException
 	 * @throws  \RuntimeException
 	 */
 	public function __construct($options = array())
@@ -41,11 +44,18 @@ class Curl implements TransportInterface
 			throw new \RuntimeException('Cannot use a cURL transport when curl_init() is not available.');
 		}
 
+		if (!is_array($options) && !($options instanceof \ArrayAccess))
+		{
+			throw new \InvalidArgumentException(
+				'The options param must be an array or implement the ArrayAccess interface.'
+			);
+		}
+
 		$this->options = $options;
 	}
 
 	/**
-	 * Send a request to the server and return a JHttpResponse object with the response.
+	 * Send a request to the server and return a Response object with the response.
 	 *
 	 * @param   string        $method     The HTTP method for sending the request.
 	 * @param   UriInterface  $uri        The URI to the resource to request.

--- a/src/Transport/Socket.php
+++ b/src/Transport/Socket.php
@@ -21,13 +21,17 @@ use Joomla\Uri\Uri;
 class Socket implements TransportInterface
 {
 	/**
-	 * @var    array  Reusable socket connections.
+	 * Reusable socket connections.
+	 *
+	 * @var    array
 	 * @since  1.0
 	 */
 	protected $connections;
 
 	/**
-	 * @var    array  The client options.
+	 * The client options.
+	 *
+	 * @var    array|\ArrayAccess
 	 * @since  1.0
 	 */
 	protected $options;
@@ -35,7 +39,7 @@ class Socket implements TransportInterface
 	/**
 	 * Constructor.
 	 *
-	 * @param   array  $options  Client options object.
+	 * @param   array|\ArrayAccess  $options  Client options array.
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
@@ -47,11 +51,18 @@ class Socket implements TransportInterface
 			throw new \RuntimeException('Cannot use a socket transport when fsockopen() is not available.');
 		}
 
+		if (!is_array($options) && !($options instanceof \ArrayAccess))
+		{
+			throw new \InvalidArgumentException(
+				'The options param must be an array or implement the ArrayAccess interface.'
+			);
+		}
+
 		$this->options = $options;
 	}
 
 	/**
-	 * Send a request to the server and return a JHttpResponse object with the response.
+	 * Send a request to the server and return a Response object with the response.
 	 *
 	 * @param   string        $method     The HTTP method for sending the request.
 	 * @param   UriInterface  $uri        The URI to the resource to request.

--- a/src/Transport/Stream.php
+++ b/src/Transport/Stream.php
@@ -20,7 +20,9 @@ use Joomla\Uri\UriInterface;
 class Stream implements TransportInterface
 {
 	/**
-	 * @var    array  The client options.
+	 * The client options.
+	 *
+	 * @var    array|\ArrayAccess
 	 * @since  1.0
 	 */
 	protected $options;
@@ -28,7 +30,7 @@ class Stream implements TransportInterface
 	/**
 	 * Constructor.
 	 *
-	 * @param   array  $options  Client options object.
+	 * @param   array|\ArrayAccess  $options  Client options array.
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
@@ -47,11 +49,18 @@ class Stream implements TransportInterface
 			throw new \RuntimeException('Cannot use a stream transport when "allow_url_fopen" is disabled.');
 		}
 
+		if (!is_array($options) && !($options instanceof \ArrayAccess))
+		{
+			throw new \InvalidArgumentException(
+				'The options param must be an array or implement the ArrayAccess interface.'
+			);
+		}
+
 		$this->options = $options;
 	}
 
 	/**
-	 * Send a request to the server and return a JHttpResponse object with the response.
+	 * Send a request to the server and return a Response object with the response.
 	 *
 	 * @param   string        $method     The HTTP method for sending the request.
 	 * @param   UriInterface  $uri        The URI to the resource to request.

--- a/src/TransportInterface.php
+++ b/src/TransportInterface.php
@@ -20,14 +20,14 @@ interface TransportInterface
 	/**
 	 * Constructor.
 	 *
-	 * @param   array  $options  Client options object.
+	 * @param   array|\ArrayAccess  $options  Client options object.
 	 *
 	 * @since   1.0
 	 */
 	public function __construct($options = array());
 
 	/**
-	 * Send a request to the server and return a JHttpResponse object with the response.
+	 * Send a request to the server and return a Response object with the response.
 	 *
 	 * @param   string        $method     The HTTP method for sending the request.
 	 * @param   UriInterface  $uri        The URI to the resource to request.
@@ -43,7 +43,7 @@ interface TransportInterface
 	public function request($method, UriInterface $uri, $data = null, array $headers = null, $timeout = null, $userAgent = null);
 
 	/**
-	 * Method to check if http transport layer available for using
+	 * Method to check if HTTP transport layer available for using
 	 *
 	 * @return  boolean  True if available else false
 	 *


### PR DESCRIPTION
The package works with either an array or `ArrayAccess` object for the options param where specified.  This PR updates doc blocks to specify this and tests that the param meets this criteria.

Also, `HttpFactory::getAvailableDriver()` required the options param to be injected, only to be injected into the transport it creates.  As the transport options are optional, this should not be required here.