### PR TITLE
Add a check for safe_mode or open_basedir

### DIFF
--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -149,8 +149,14 @@ class Curl implements TransportInterface
 		// Link: http://the-stickman.com/web-development/php-and-curl-disabling-100-continue-header/
 		$options[CURLOPT_HTTPHEADER][] = 'Expect:';
 
-		// Follow redirects.
-		$options[CURLOPT_FOLLOWLOCATION] = (bool) (isset($this->options['follow_location']) ? $this->options['follow_location'] : true);
+		/*
+		 * Follow redirects if server config allows
+		 * @deprecated  safe_mode is removed in PHP 5.4, check will be dropped when PHP 5.3 support is dropped
+		 */
+		if (!ini_get('safe_mode') && !ini_get('open_basedir'))
+		{
+			$options[CURLOPT_FOLLOWLOCATION] = (bool) isset($this->options['follow_location']) ? $this->options['follow_location'] : true;
+		}
 
 		// Set any custom transport options
 		if (isset($this->options['transport.curl']))


### PR DESCRIPTION
Prevents a `Warning: curl_setopt_array(): CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set in /vendor/joomla/http/src/Transport/Curl.php on line 155` message in PHP 5.3 when open_basedir is set or safe_mode is enabled.