### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/src/Transport/Socket.php
+++ b/src/Transport/Socket.php
@@ -252,7 +252,7 @@ class Socket implements TransportInterface
 		$err = null;
 
 		// Get the host from the uri.
-		$host = ($uri->isSSL()) ? 'ssl://' . $uri->getHost() : $uri->getHost();
+		$host = ($uri->isSsl()) ? 'ssl://' . $uri->getHost() : $uri->getHost();
 
 		// If the port is not explicitly set in the URI detect it.
 		if (!$uri->getPort())


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).

Not touching casing of class names as this requires changes in casing in file names and causes issues at this point.