### PR TITLE
PSR-7 Response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=5.4",
         "joomla/uri": "~1.0",
-		"zendframework/zend-diactoros": "~1.1"
+        "zendframework/zend-diactoros": "~1.1"
     },
     "require-dev": {
         "joomla/test": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,9 @@
     "homepage": "https://github.com/joomla-framework/http",
     "license": "GPL-2.0+",
     "require": {
-        "php": ">=5.3.10",
-        "joomla/uri": "~1.0"
+        "php": ">=5.4",
+        "joomla/uri": "~1.0",
+		"zendframework/zend-diactoros": "~1.1"
     },
     "require-dev": {
         "joomla/test": "~1.0",

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,7 +5,7 @@ The HTTP package includes a suite of classes to facilitate RESTful HTTP requests
 ### Making a HEAD request
 
 An HTTP HEAD request can be made using the head method passing a URL and an optional key-value array of header variables.
-The method will return a [Response](classes/Response.md) object.
+The method will return a [Response](classes/Response.md) object which is [PSR-7](http://www.php-fig.org/psr/psr-7/) compliant.
 
 ```php
 use Joomla\Http\HttpFactory;

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -1,3 +1,12 @@
 ## Updating from v1 to v2
 
-There are no major changes in the HTTP package when updating from v1 to v2.
+Version 2 of the http package started to use PSR-7 compliant packages. This means that custom transport drivers now need to formulate their `Response` object using PSR-7 compliant syntax.
+
+`
+$response = new \Joomla\Http\Response;
+$response->withBody($body);
+$response->withHeader($headerName, $headerValue);
+$response->withStatus($statusCode);
+`
+
+We encourage users of the package to use PSR-7 compliant code to retrieve information from the response object, however we are maintaining support for retrieving the body, headers and status code through the same way as in version 1 of the HTTP package.

--- a/src/Response.php
+++ b/src/Response.php
@@ -13,12 +13,18 @@ use Zend\Diactoros\Response as PsrResponse;
 /**
  * HTTP response data object class.
  *
+ * @property  string  $body     The response body as a string
+ * @property  int     $code     The status code of the response
+ * @property  array   $headers  The headers as a array
+ *
  * @since  1.0
  */
 class Response extends PsrResponse
 {
 	/**
 	 * Magic getter to keep b/c with code usage before introduction of PSR-7 interface
+	 *
+	 * @param   string  $name  The variable to return
 	 *
 	 * @return  mixed
 	 */
@@ -44,7 +50,8 @@ class Response extends PsrResponse
 			'Undefined property via __get(): ' . $name .
 			' in ' . $trace[0]['file'] .
 			' on line ' . $trace[0]['line'],
-			E_USER_NOTICE);
+			E_USER_NOTICE
+		);
 
 		return null;
 	}

--- a/src/Response.php
+++ b/src/Response.php
@@ -8,28 +8,44 @@
 
 namespace Joomla\Http;
 
+use Zend\Diactoros\Response as PsrResponse;
+
 /**
  * HTTP response data object class.
  *
  * @since  1.0
  */
-class Response
+class Response extends PsrResponse
 {
 	/**
-	 * @var    integer  The server response code.
-	 * @since  1.0
+	 * Magic getter to keep b/c with code usage before introduction of PSR-7 interface
+	 *
+	 * @return  mixed
 	 */
-	public $code;
+	public function __get($name)
+	{
+		if (strtolower($name) === 'body')
+		{
+			return (string) $this->getBody();
+		}
 
-	/**
-	 * @var    array  Response headers.
-	 * @since  1.0
-	 */
-	public $headers = array();
+		if (strtolower($name) === 'code')
+		{
+			return $this->getStatusCode();
+		}
 
-	/**
-	 * @var    string  Server response body.
-	 * @since  1.0
-	 */
-	public $body;
+		if (strtolower($name) === 'headers')
+		{
+			return $this->getHeaders();
+		}
+
+		$trace = debug_backtrace();
+		trigger_error(
+			'Undefined property via __get(): ' . $name .
+			' in ' . $trace[0]['file'] .
+			' on line ' . $trace[0]['line'],
+			E_USER_NOTICE);
+
+		return null;
+	}
 }

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -204,9 +204,6 @@ class Curl implements TransportInterface
 	 */
 	protected function getResponse($content, $info)
 	{
-		// Create the response object.
-		$return = new Response;
-
 		// Get the number of redirects that occurred.
 		$redirects = isset($info['redirect_count']) ? $info['redirect_count'] : 0;
 
@@ -218,7 +215,7 @@ class Curl implements TransportInterface
 		$response = explode("\r\n\r\n", $content, 2 + $redirects);
 
 		// Set the body for the response.
-		$return->body = array_pop($response);
+		$body = array_pop($response);
 
 		// Get the last set of response headers as an array.
 		$headers = explode("\r\n", array_pop($response));
@@ -230,7 +227,7 @@ class Curl implements TransportInterface
 
 		if (is_numeric($code))
 		{
-			$return->code = (int) $code;
+			$statusCode = (int) $code;
 		}
 
 		// No valid response code was detected.
@@ -239,14 +236,16 @@ class Curl implements TransportInterface
 			throw new \UnexpectedValueException('No HTTP response code found.');
 		}
 
+		$verifiedHeaders = array();
+
 		// Add the response headers to the response object.
 		foreach ($headers as $header)
 		{
 			$pos = strpos($header, ':');
-			$return->headers[trim(substr($header, 0, $pos))] = trim(substr($header, ($pos + 1)));
+			$verifiedHeaders[trim(substr($header, 0, $pos))] = trim(substr($header, ($pos + 1)));
 		}
 
-		return $return;
+		return new Response($body, $statusCode, $verifiedHeaders);
 	}
 
 	/**

--- a/src/Transport/Socket.php
+++ b/src/Transport/Socket.php
@@ -194,9 +194,6 @@ class Socket implements TransportInterface
 	 */
 	protected function getResponse($content)
 	{
-		// Create the response object.
-		$return = new Response;
-
 		if (empty($content))
 		{
 			throw new \UnexpectedValueException('No content in response.');
@@ -209,7 +206,7 @@ class Socket implements TransportInterface
 		$headers = explode("\r\n", $response[0]);
 
 		// Set the body for the response.
-		$return->body = empty($response[1]) ? '' : $response[1];
+		$body = empty($response[1]) ? '' : $response[1];
 
 		// Get the response code from the first offset of the response headers.
 		preg_match('/[0-9]{3}/', array_shift($headers), $matches);
@@ -217,7 +214,7 @@ class Socket implements TransportInterface
 
 		if (is_numeric($code))
 		{
-			$return->code = (int) $code;
+			$statusCode = (int) $code;
 		}
 		else
 		// No valid response code was detected.
@@ -225,14 +222,16 @@ class Socket implements TransportInterface
 			throw new \UnexpectedValueException('No HTTP response code found.');
 		}
 
+		$verifiedHeaders = array();
+
 		// Add the response headers to the response object.
 		foreach ($headers as $header)
 		{
 			$pos = strpos($header, ':');
-			$return->headers[trim(substr($header, 0, $pos))] = trim(substr($header, ($pos + 1)));
+			$verifiedHeaders[trim(substr($header, 0, $pos))] = trim(substr($header, ($pos + 1)));
 		}
 
-		return $return;
+		return new Response($body, $statusCode, $verifiedHeaders);
 	}
 
 	/**

--- a/src/Transport/Stream.php
+++ b/src/Transport/Stream.php
@@ -210,19 +210,13 @@ class Stream implements TransportInterface
 	 */
 	protected function getResponse(array $headers, $body)
 	{
-		// Create the response object.
-		$return = new Response;
-
-		// Set the body for the response.
-		$return->body = $body;
-
 		// Get the response code from the first offset of the response headers.
 		preg_match('/[0-9]{3}/', array_shift($headers), $matches);
 		$code = $matches[0];
 
 		if (is_numeric($code))
 		{
-			$return->code = (int) $code;
+			$statusCode = (int) $code;
 		}
 
 		// No valid response code was detected.
@@ -231,14 +225,16 @@ class Stream implements TransportInterface
 			throw new \UnexpectedValueException('No HTTP response code found.');
 		}
 
+		$verifiedHeaders = array();
+
 		// Add the response headers to the response object.
 		foreach ($headers as $header)
 		{
 			$pos = strpos($header, ':');
-			$return->headers[trim(substr($header, 0, $pos))] = trim(substr($header, ($pos + 1)));
+			$verifiedHeaders[trim(substr($header, 0, $pos))] = trim(substr($header, ($pos + 1)));
 		}
 
-		return $return;
+		return new Response($body, $statusCode, $verifiedHeaders);
 	}
 
 	/**


### PR DESCRIPTION
This uses PSR-7 responses for HTTP requests rather than our custom rather lacking class. To keep things easy it adds a dependency on the zend-diactoros package (new BSD license which is GPL compatible).

I chose zend over the guzzle package because guzzle's package still isn't complete in a few areas (not areas that we are using - but I still would prefer to use the most complete available package).

I've added some magic getters into the Response class so that people using the old style getters are unaffected by this change. The only b/c implications are to those creating the class with their own transport drivers

The zend package requires PHP 5.4 - so this would obviously reflect into the package we have