### PR TITLE
Make the HttpFactory methods non-static

### DIFF
--- a/Tests/HttpFactoryTest.php
+++ b/Tests/HttpFactoryTest.php
@@ -10,86 +10,92 @@ use Joomla\Http\HttpFactory;
 
 /**
  * Test class for Joomla\Http\HttpFactory.
- *
- * @since  1.0
  */
-class FactoryTest extends \PHPUnit_Framework_TestCase
+class HttpFactoryTest extends \PHPUnit_Framework_TestCase
 {
+	/**
+	 * Object being tested
+	 *
+	 * @var  HttpFactory
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the fixture, for example, open a network connection.
+	 *
+	 * @return  void
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->instance = new HttpFactory;
+	}
+
 	/**
 	 * Tests the getHttp method.
 	 *
-	 * @return  void
-	 *
 	 * @covers  Joomla\Http\HttpFactory::getHttp
-	 * @since   1.0
 	 */
 	public function testGetHttp()
 	{
 		$this->assertInstanceOf(
 			'Joomla\\Http\\Http',
-			HttpFactory::getHttp()
+			$this->instance->getHttp()
 		);
 	}
 
 	/**
 	 * Tests the getHttp method to ensure only arrays or ArrayAccess objects are allowed
 	 *
-	 * @return  void
-	 *
 	 * @covers             Joomla\Http\HttpFactory::getHttp
 	 * @expectedException  \InvalidArgumentException
 	 */
 	public function testGetHttpDisallowsNonArrayObjects()
 	{
-		HttpFactory::getHttp(new \stdClass);
+		$this->instance->getHttp(new \stdClass);
 	}
 
 	/**
 	 * Tests the getHttp method.
 	 *
-	 * @return  void
-	 *
 	 * @covers  Joomla\Http\HttpFactory::getHttp
 	 * @expectedException RuntimeException
-	 * @since   1.1.4
 	 */
 	public function testGetHttpException()
 	{
 		$this->assertInstanceOf(
 			'Joomla\\Http\\Http',
-			HttpFactory::getHttp(array(), array())
+			$this->instance->getHttp([], [])
 		);
 	}
 
 	/**
 	 * Tests the getAvailableDriver method.
 	 *
-	 * @return  void
-	 *
 	 * @covers  Joomla\Http\HttpFactory::getAvailableDriver
-	 * @since   1.0
 	 */
 	public function testGetAvailableDriver()
 	{
 		$this->assertInstanceOf(
 			'Joomla\\Http\\TransportInterface',
-			HttpFactory::getAvailableDriver(array(), null)
+			$this->instance->getAvailableDriver([], null)
 		);
 
 		$this->assertFalse(
-			HttpFactory::getAvailableDriver(array(), array()),
+			$this->instance->getAvailableDriver([], []),
 			'Passing an empty array should return false due to there being no adapters to test'
 		);
 
 		$this->assertFalse(
-			HttpFactory::getAvailableDriver(array(), array('fopen')),
+			$this->instance->getAvailableDriver([], ['fopen']),
 			'A false should be returned if a class is not present or supported'
 		);
 
 		include_once __DIR__ . '/stubs/DummyTransport.php';
 
 		$this->assertFalse(
-			HttpFactory::getAvailableDriver(array(), array('DummyTransport')),
+			$this->instance->getAvailableDriver([], ['DummyTransport']),
 			'Passing an empty array should return false due to there being no adapters to test'
 		);
 	}
@@ -97,32 +103,27 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * Tests the getAvailableDriver method to ensure only arrays or ArrayAccess objects are allowed
 	 *
-	 * @return  void
-	 *
 	 * @covers             Joomla\Http\HttpFactory::getAvailableDriver
 	 * @expectedException  \InvalidArgumentException
 	 */
 	public function testGetAvailableDriverDisallowsNonArrayObjects()
 	{
-		HttpFactory::getAvailableDriver(new \stdClass);
+		$this->instance->getAvailableDriver(new \stdClass);
 	}
 
 	/**
 	 * Tests the getHttpTransports method.
 	 *
-	 * @return  void
-	 *
 	 * @covers  Joomla\Http\HttpFactory::getHttpTransports
-	 * @since   1.1.4
 	 */
 	public function testGetHttpTransports()
 	{
-		$transports = array('Stream', 'Socket', 'Curl');
+		$transports = ['Stream', 'Socket', 'Curl'];
 		sort($transports);
 
 		$this->assertEquals(
 			$transports,
-			HttpFactory::getHttpTransports()
+			$this->instance->getHttpTransports()
 		);
 	}
 }

--- a/docs/classes/HttpFactory.md
+++ b/docs/classes/HttpFactory.md
@@ -11,7 +11,7 @@ The `getHttp()` method can be used to create `Http` objects from the factory.
  * @param   array|\ArrayAccess  $options   Client options array.
  * @param   array|string        $adapters  Adapter (string) or queue of adapters (array) to use for communication.
  */
-public static function getHttp($options = array(), $adapters = null)
+public function getHttp($options = array(), $adapters = null)
 ```
 
 The following example demonstrates basic use of the `getHttp()` method.
@@ -20,7 +20,7 @@ The following example demonstrates basic use of the `getHttp()` method.
 use Joomla\Http\HttpFactory;
 
 // Create an instance of a default Http object.
-$http = HttpFactory::getHttp();
+$http = (new HttpFactory)->getHttp();
 ```
 
 Note that a `RuntimeException` is thrown if no `TransportInterface` objects are available for use.
@@ -34,7 +34,7 @@ The `getAvailableDriver()` method can be used to create [TransportInterface](Tra
  * @param   array|\ArrayAccess  $options  Options for creating TransportInterface object
  * @param   array|string        $default  Adapter (string) or queue of adapters (array) to use
  */
-public static function getAvailableDriver($options = array(), $default = null)
+public function getAvailableDriver($options = array(), $default = null)
 ```
 
 The following example demonstrates basic use of the `getAvailableDriver()` method.
@@ -43,7 +43,7 @@ The following example demonstrates basic use of the `getAvailableDriver()` metho
 use Joomla\Http\HttpFactory;
 
 // Create an instance of a TransportInterface object.
-$transport = HttpFactory::getAvailableDriver();
+$transport = (new HttpFactory)->getAvailableDriver();
 ```
 
 ### Retrieving the available TransportInterface implementations
@@ -51,7 +51,7 @@ $transport = HttpFactory::getAvailableDriver();
 The `getHttpTransports()` method can be used to retrieve a list of supported [TransportInterface](TransportInterface.md) objects from the factory. 
 
 ```php
-public static function getHttpTransports()
+public function getHttpTransports()
 ```
 
 The following example demonstrates basic use of the `getHttpTransports()` method.
@@ -60,6 +60,6 @@ The following example demonstrates basic use of the `getHttpTransports()` method
 use Joomla\Http\HttpFactory;
 
 // Get a list of available TransportInterface objects.
-$transports = HttpFactory::getHttpTransports();
+$transports = (new HttpFactory)->getHttpTransports();
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,7 +11,7 @@ An HTTP HEAD request can be made using the head method passing a URL and an opti
 use Joomla\Http\HttpFactory;
 
 // Create an instance of a default Http object.
-$http = HttpFactory::getHttp();
+$http = (new HttpFactory)->getHttp();
 
 // Invoke the HEAD request.
 $response = $http->head('http://example.com');

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -18,3 +18,7 @@ $response->withStatus($statusCode);
 
 We encourage users of the package to use PSR-7 compliant code to retrieve information from the response object, however we are maintaining
 support for retrieving the body, headers and status code through the same way as in version 1 of the HTTP package.
+
+### Factory class methods no longer static
+
+The methods of the `HttpFactory` class are no longer static.  Users must now instantiate the factory class to access its methods.

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -27,7 +27,7 @@ class HttpFactory
 	 * @throws  \InvalidArgumentException
 	 * @throws  \RuntimeException
 	 */
-	public static function getHttp($options = array(), $adapters = null)
+	public function getHttp($options = array(), $adapters = null)
 	{
 		if (!is_array($options) && !($options instanceof \ArrayAccess))
 		{
@@ -36,7 +36,7 @@ class HttpFactory
 			);
 		}
 
-		if (!$driver = self::getAvailableDriver($options, $adapters))
+		if (!$driver = $this->getAvailableDriver($options, $adapters))
 		{
 			throw new \RuntimeException('No transport driver available.');
 		}
@@ -55,7 +55,7 @@ class HttpFactory
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
 	 */
-	public static function getAvailableDriver($options = array(), $default = null)
+	public function getAvailableDriver($options = array(), $default = null)
 	{
 		if (!is_array($options) && !($options instanceof \ArrayAccess))
 		{
@@ -66,7 +66,7 @@ class HttpFactory
 
 		if (is_null($default))
 		{
-			$availableAdapters = self::getHttpTransports();
+			$availableAdapters = $this->getHttpTransports();
 		}
 		else
 		{
@@ -82,7 +82,7 @@ class HttpFactory
 
 		foreach ($availableAdapters as $adapter)
 		{
-			/* @var  $class  TransportInterface */
+			/** @var $class TransportInterface */
 			$class = 'Joomla\\Http\\Transport\\' . ucfirst($adapter);
 
 			if (class_exists($class))
@@ -104,12 +104,12 @@ class HttpFactory
 	 *
 	 * @since   1.0
 	 */
-	public static function getHttpTransports()
+	public function getHttpTransports()
 	{
 		$names = array();
 		$iterator = new \DirectoryIterator(__DIR__ . '/Transport');
 
-		/*  @var  $file  \DirectoryIterator */
+		/** @var $file \DirectoryIterator */
 		foreach ($iterator as $file)
 		{
 			$fileName = $file->getFilename();

--- a/src/Response.php
+++ b/src/Response.php
@@ -17,7 +17,7 @@ use Zend\Diactoros\Response as PsrResponse;
  * @property  integer  $code     The status code of the response
  * @property  array    $headers  The headers as an array
  *
- * @since     1.0
+ * @since  1.0
  */
 class Response extends PsrResponse
 {


### PR DESCRIPTION
This changes the `HttpFactory` class to use non-static methods which enables the factory to be mocked in applications.