### PR TITLE
Add two custom Exception types

### DIFF
--- a/src/Exception/InvalidResponseCodeException.php
+++ b/src/Exception/InvalidResponseCodeException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Part of the Joomla Framework Http Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Http\Exception;
+
+/**
+ * Exception representing an invalid or undefined HTTP response code
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class InvalidResponseCodeException extends \UnexpectedValueException
+{
+}

--- a/src/Exception/UnexpectedResponseException.php
+++ b/src/Exception/UnexpectedResponseException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Part of the Joomla Framework Http Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Http\Exception;
+
+/**
+ * Exception representing an unexpected response
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class UnexpectedResponseException extends \DomainException
+{
+}

--- a/src/Exception/UnexpectedResponseException.php
+++ b/src/Exception/UnexpectedResponseException.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\Http\Exception;
 
+use Joomla\Http\Response;
+
 /**
  * Exception representing an unexpected response
  *
@@ -15,4 +17,40 @@ namespace Joomla\Http\Exception;
  */
 class UnexpectedResponseException extends \DomainException
 {
+	/**
+	 * The Response object.
+	 *
+	 * @var    Response
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $response;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   Response    $response  The Response object.
+	 * @param   string      $message   The Exception message to throw.
+	 * @param   integer     $code      The Exception code.
+	 * @param   \Exception  $previous  The previous exception used for the exception chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(Response $response, $message = '', $code = 0, \Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->response = $response;
+	}
+
+	/**
+	 * Get the Response object.
+	 *
+	 * @return  Response
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getResponse()
+	{
+		return $this->response;
+	}
 }

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Http\Transport;
 
+use Joomla\Http\Exception\InvalidResponseCodeException;
 use Joomla\Http\TransportInterface;
 use Joomla\Http\Response;
 use Joomla\Uri\UriInterface;
@@ -206,7 +207,7 @@ class Curl implements TransportInterface
 	 * @return  Response
 	 *
 	 * @since   1.0
-	 * @throws  \UnexpectedValueException
+	 * @throws  InvalidResponseCodeException
 	 */
 	protected function getResponse($content, $info)
 	{
@@ -242,7 +243,7 @@ class Curl implements TransportInterface
 		// No valid response code was detected.
 		else
 		{
-			throw new \UnexpectedValueException('No HTTP response code found.');
+			throw new InvalidResponseCodeException('No HTTP response code found.');
 		}
 
 		// Add the response headers to the response object.

--- a/src/Transport/Socket.php
+++ b/src/Transport/Socket.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Http\Transport;
 
+use Joomla\Http\Exception\InvalidResponseCodeException;
 use Joomla\Http\TransportInterface;
 use Joomla\Http\Response;
 use Joomla\Uri\UriInterface;
@@ -191,6 +192,7 @@ class Socket implements TransportInterface
 	 *
 	 * @since   1.0
 	 * @throws  \UnexpectedValueException
+	 * @throws  InvalidResponseCodeException
 	 */
 	protected function getResponse($content)
 	{
@@ -222,7 +224,7 @@ class Socket implements TransportInterface
 		else
 		// No valid response code was detected.
 		{
-			throw new \UnexpectedValueException('No HTTP response code found.');
+			throw new InvalidResponseCodeException('No HTTP response code found.');
 		}
 
 		// Add the response headers to the response object.

--- a/src/Transport/Stream.php
+++ b/src/Transport/Stream.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Http\Transport;
 
+use Joomla\Http\Exception\InvalidResponseCodeException;
 use Joomla\Http\TransportInterface;
 use Joomla\Http\Response;
 use Joomla\Uri\UriInterface;
@@ -206,7 +207,7 @@ class Stream implements TransportInterface
 	 * @return  Response
 	 *
 	 * @since   1.0
-	 * @throws  \UnexpectedValueException
+	 * @throws  InvalidResponseCodeException
 	 */
 	protected function getResponse(array $headers, $body)
 	{
@@ -224,11 +225,10 @@ class Stream implements TransportInterface
 		{
 			$return->code = (int) $code;
 		}
-
 		// No valid response code was detected.
 		else
 		{
-			throw new \UnexpectedValueException('No HTTP response code found.');
+			throw new InvalidResponseCodeException('No HTTP response code found.');
 		}
 
 		// Add the response headers to the response object.


### PR DESCRIPTION
This PR adds two custom Exception classes to the package:

- `InvalidResponseCodeException`: To be thrown when the HTTP response code is invalid or not set, extends `\UnexpectedValueException` and is thrown in place of the current exceptions catching this condition
- `UnexpectedResponseException`: Generic Exception to be thrown by a library if the Response is not as expected; this would be a replacement for the `\DomainException` that gets thrown in our API libraries (which is why this new Exception extends that one)