### PR TITLE
Use composer/ca-bundle for cacert file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "license": "GPL-2.0+",
     "require": {
         "php": ">=5.3.10|>=7.0",
-        "joomla/uri": "~1.0"
+        "joomla/uri": "~1.0",
+        "composer/ca-bundle": "~1.0"
     },
     "require-dev": {
         "joomla/test": "~1.0",

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Http\Transport;
 
+use Composer\CaBundle\CaBundle;
 use Joomla\Http\Exception\InvalidResponseCodeException;
 use Joomla\Http\TransportInterface;
 use Joomla\Http\Response;
@@ -82,7 +83,7 @@ class Curl implements TransportInterface
 		$options[CURLOPT_NOBODY] = ($method === 'HEAD');
 
 		// Initialize the certificate store
-		$options[CURLOPT_CAINFO] = isset($this->options['curl.certpath']) ? $this->options['curl.certpath'] : __DIR__ . '/cacert.pem';
+		$options[CURLOPT_CAINFO] = isset($this->options['curl.certpath']) ? $this->options['curl.certpath'] : CaBundle::getSystemCaRootBundlePath();
 
 		// If data exists let's encode it and make sure our Content-type header is set.
 		if (isset($data))


### PR DESCRIPTION
The `composer/ca-bundle` package has a more in depth code structure for selecting a cacert file which also attempts to use the local server's file before finally falling back on a bundled file (a modified version of the Mozilla file).  As of 2.0 we should stop shipping our cacert file.