### PR TITLE
Use `@link` over `@see` and move PHP Link to https

### DIFF
--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -34,7 +34,7 @@ class Curl implements TransportInterface
 	 *
 	 * @param   array|\ArrayAccess  $options  Client options array.
 	 *
-	 * @see     http://www.php.net/manual/en/function.curl-setopt.php
+	 * @link    https://secure.php.net/manual/en/function.curl-setopt.php
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
 	 * @throws  \RuntimeException


### PR DESCRIPTION
### Summary of Changes

Use `@link` over `@see` and move PHP Link to https

### Testing Instructions

Review

### Documentation Changes Required

None