### PR TITLE
Support sending requests with a PSR-7 object

### DIFF
--- a/Tests/HttpTest.php
+++ b/Tests/HttpTest.php
@@ -10,6 +10,7 @@ use Joomla\Http\Http;
 use Joomla\Uri\Uri;
 use Joomla\Test\TestHelper;
 use PHPUnit\Framework\TestCase;
+use Zend\Diactoros\Request;
 
 /**
  * Test class for Joomla\Http\Http.
@@ -317,6 +318,37 @@ class HttpTest extends TestCase
 		$this->assertThat(
 			$this->object->patch('http://example.com', array('key' => 'value'), array('testHeader')),
 			$this->equalTo('ReturnString')
+		);
+	}
+
+	/**
+	 * Tests the sendRequest method
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSendRequest()
+	{
+		$this->transport->expects($this->once())
+			->method('request')
+			->with(
+				'GET',
+				new Uri('http://example.com'),
+				'',
+				[
+					'Host'       => ['example.com'],
+					'testHeader' => [''],
+				]
+			)
+			->willReturn('ReturnString');
+
+		$request = new Request('http://example.com', 'GET');
+		$request = $request->withHeader('testHeader', '');
+
+		$this->assertEquals(
+			'ReturnString',
+			$this->object->sendRequest($request)
 		);
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": "^5.5.9|~7.0",
         "joomla/uri": "~1.0|~2.0",
         "composer/ca-bundle": "~1.0",
+        "psr/http-message": "~1.0",
         "zendframework/zend-diactoros": "~1.1"
     },
     "require-dev": {

--- a/src/Http.php
+++ b/src/Http.php
@@ -235,9 +235,9 @@ class Http
 	}
 
 	/**
-	 * Send a request to a remote server based on a PSR-7 RequestInterface object
+	 * Send a request to a remote server based on a PSR-7 RequestInterface object.
 	 *
-	 * @param   RequestInterface  $request
+	 * @param   RequestInterface  $request  The PSR-7 request object.
 	 *
 	 * @return  Response
 	 *

--- a/src/Http.php
+++ b/src/Http.php
@@ -10,6 +10,7 @@ namespace Joomla\Http;
 
 use Joomla\Uri\Uri;
 use Joomla\Uri\UriInterface;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * HTTP client class.
@@ -231,6 +232,25 @@ class Http
 	public function patch($url, $data, array $headers = [], $timeout = null)
 	{
 		return $this->makeTransportRequest('PATCH', $url, $data, $headers, $timeout);
+	}
+
+	/**
+	 * Send a request to a remote server based on a PSR-7 RequestInterface object
+	 *
+	 * @param   RequestInterface  $request
+	 *
+	 * @return  Response
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function sendRequest(RequestInterface $request)
+	{
+		return $this->makeTransportRequest(
+			$request->getMethod(),
+			new Uri((string) $request->getUri()),
+			$request->getBody()->getContents(),
+			$request->getHeaders()
+		);
 	}
 
 	/**

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -95,11 +95,21 @@ class Curl extends AbstractTransport
 		// Build the headers string for the request.
 		$headerArray = [];
 
-		if (isset($headers))
+		if (!empty($headers))
 		{
 			foreach ($headers as $key => $value)
 			{
-				$headerArray[] = $key . ': ' . $value;
+				if (is_array($value))
+				{
+					foreach ($value as $header)
+					{
+						$headerArray[] = "$key: $header";
+					}
+				}
+				else
+				{
+					$headerArray[] = "$key: $value";
+				}
 			}
 
 			// Add the headers string into the stream context options array.

--- a/src/Transport/Socket.php
+++ b/src/Transport/Socket.php
@@ -103,11 +103,21 @@ class Socket extends AbstractTransport
 		}
 
 		// If there are custom headers to send add them to the request payload.
-		if (is_array($headers))
+		if (!empty($headers))
 		{
-			foreach ($headers as $k => $v)
+			foreach ($headers as $key => $value)
 			{
-				$request[] = $k . ': ' . $v;
+				if (is_array($value))
+				{
+					foreach ($value as $header)
+					{
+						$request[] = "$key: $header";
+					}
+				}
+				else
+				{
+					$request[] = "$key: $value";
+				}
 			}
 		}
 

--- a/src/Transport/Stream.php
+++ b/src/Transport/Stream.php
@@ -102,13 +102,23 @@ class Stream extends AbstractTransport
 		}
 
 		// Build the headers string for the request.
-		$headerString = null;
-
-		if (isset($headers))
+		if (!empty($headers))
 		{
+			$headerString = '';
+
 			foreach ($headers as $key => $value)
 			{
-				$headerString .= $key . ': ' . $value . "\r\n";
+				if (is_array($value))
+				{
+					foreach ($value as $header)
+					{
+						$headerString .= "$key: $header\r\n";
+					}
+				}
+				else
+				{
+					$headerString .= "$key: $value\r\n";
+				}
 			}
 
 			// Add the headers string into the stream context options array.


### PR DESCRIPTION
### Summary of Changes

- Adds `\Joomla\Http\Http::sendRequest(\Psr\Http\Message\RequestInterface $request) : \Joomla\Http\Response` to support sending requests using a PSR-7 request object as the data source for the request
- Adds supports for PSR-7 style headers arrays to the transport adapters