### PR TITLE
Don't include tests in composer distributions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,8 @@
-.gitattributes export-ignore
-.gitignore export-ignore
-.travis.yml export-ignore
-.travis export-ignore
+/.github export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/.travis export-ignore
+/phpunit.travis.xml export-ignore
+/phpunit.xml.dist export-ignore
+/Tests export-ignore


### PR DESCRIPTION
Tests are not needed when the package is installed as a dependency.

Pull Request for Issue #

### Summary of Changes

Tests and test related files have been removed from the ZIP files that Composer downloads. 

### Testing Instructions

Create a new release, install via Composer and validate that Tests are excluded.

### Documentation Changes Required
N/A