### PR TITLE
Remove Typehint for proposed PSR Http Client Compat

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -243,7 +243,7 @@ class Http
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function sendRequest(RequestInterface $request): Response
+	public function sendRequest(RequestInterface $request)
 	{
 		return $this->makeTransportRequest(
 			$request->getMethod(),


### PR DESCRIPTION
Allows us to be compliant with https://github.com/php-http/fig-standards/blob/master/proposed/http-client/http-client.md#httpclientinterface whilst PSR still don't do PHP 7.0 minimum interfaces