### PR TITLE
Data should be null if there isn't any

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -245,10 +245,12 @@ class Http
 	 */
 	public function sendRequest(RequestInterface $request)
 	{
+		$data = $request->getBody()->getContents();
+
 		return $this->makeTransportRequest(
 			$request->getMethod(),
 			new Uri((string) $request->getUri()),
-			$request->getBody()->getContents(),
+			empty($data) ? null : $data,
 			$request->getHeaders()
 		);
 	}


### PR DESCRIPTION
At the moment all the transport layers use `isset` checks on `$data` as data is null if there isn't any data. However with PSR-7 requests no data is an empty string. That ends up in the curl driver for example as `GET` requests being sent as a `POST`.