### PR TITLE
Correctly use the CaBundle package

### DIFF
--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -223,19 +223,31 @@ class Curl implements TransportInterface
 		return $this->getResponse($content, $info);
 	}
 
+	/**
+	 * Configure the cURL resources with the appropriate root certificates.
+	 *
+	 * @param   resource $ch The cURL resource you want to configure the certificates on.
+	 * @return  void
+	 */
 	protected function setCAOptionAndValue($ch)
 	{
-		if (isset($this->options['curl.certpath'])) {
+		if (isset($this->options['curl.certpath']))
+		{
 			// Option is passed to a .PEM file.
 			curl_setopt($ch, CURLOPT_CAINFO, $this->options['curl.certpath']);
+
 			return;
 		}
 
 		$caPathOrFile = CaBundle::getSystemCaRootBundlePath();
-		if (is_dir($caPathOrFile) || (is_link($caPathOrFile) && is_dir(readlink($caPathOrFile)))) {
+
+		if (is_dir($caPathOrFile) || (is_link($caPathOrFile) && is_dir(readlink($caPathOrFile))))
+		{
 			curl_setopt($ch, CURLOPT_CAPATH, $caPathOrFile);
+
 			return;
 		}
+
 		curl_setopt($ch, CURLOPT_CAINFO, $caPathOrFile);
 	}
 

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -226,8 +226,11 @@ class Curl implements TransportInterface
 	/**
 	 * Configure the cURL resources with the appropriate root certificates.
 	 *
-	 * @param   resource $ch The cURL resource you want to configure the certificates on.
+	 * @param   resource  $ch  The cURL resource you want to configure the certificates on.
+	 *
 	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function setCAOptionAndValue($ch)
 	{

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -76,6 +76,9 @@ class Curl implements TransportInterface
 		// Setup the cURL handle.
 		$ch = curl_init();
 
+		// Initialize the certificate store
+		$this->setCAOptionAndValue($ch);
+
 		$options = array();
 
 		// Set the request method.
@@ -96,9 +99,6 @@ class Curl implements TransportInterface
 
 		// Don't wait for body when $method is HEAD
 		$options[CURLOPT_NOBODY] = ($method === 'HEAD');
-
-		// Initialize the certificate store
-		$options[CURLOPT_CAINFO] = isset($this->options['curl.certpath']) ? $this->options['curl.certpath'] : CaBundle::getSystemCaRootBundlePath();
 
 		// If data exists let's encode it and make sure our Content-type header is set.
 		if (isset($data))
@@ -221,6 +221,22 @@ class Curl implements TransportInterface
 		curl_close($ch);
 
 		return $this->getResponse($content, $info);
+	}
+
+	protected function setCAOptionAndValue($ch)
+	{
+		if (isset($this->options['curl.certpath'])) {
+			// Option is passed to a .PEM file.
+			curl_setopt($ch, CURLOPT_CAINFO, $this->options['curl.certpath']);
+			return;
+		}
+
+		$caPathOrFile = CaBundle::getSystemCaRootBundlePath();
+		if (is_dir($caPathOrFile) || (is_link($caPathOrFile) && is_dir(readlink($caPathOrFile)))) {
+			curl_setopt($ch, CURLOPT_CAPATH, $caPathOrFile);
+			return;
+		}
+		curl_setopt($ch, CURLOPT_CAINFO, $caPathOrFile);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

`CaBundle::getSystemCaRootBundlePath()` can return both a directory and a file. 

Depending on if it is a file or a directory, the right cURL option must be used. 

Part of the implementation is copied from the example on https://github.com/composer/ca-bundle. 

### Testing Instructions

n/a

### Documentation Changes Required

n/a