### PR TITLE
Make the Http class and custom exceptions implement PSR-18

### DIFF
--- a/Tests/HttpTest.php
+++ b/Tests/HttpTest.php
@@ -7,6 +7,7 @@
 namespace Joomla\Http\Tests;
 
 use Joomla\Http\Http;
+use Joomla\Http\Response;
 use Joomla\Uri\Uri;
 use Joomla\Test\TestHelper;
 use PHPUnit\Framework\TestCase;
@@ -208,7 +209,7 @@ class HttpTest extends TestCase
 	 * @since   1.0
 	 *
 	 * @expectedException  \InvalidArgumentException
-	 * @expectedExceptionMessage  A string or UriInterface object must be provided, a "array" was provided.
+	 * @expectedExceptionMessage  A string or Joomla\Uri\UriInterface object must be provided, a "array" was provided.
 	 */
 	public function testGetWithInvalidUrl()
 	{
@@ -330,6 +331,8 @@ class HttpTest extends TestCase
 	 */
 	public function testSendRequest()
 	{
+		$response = new Response;
+
 		$this->transport->expects($this->once())
 			->method('request')
 			->with(
@@ -341,13 +344,13 @@ class HttpTest extends TestCase
 					'testHeader' => [''],
 				]
 			)
-			->willReturn('ReturnString');
+			->willReturn($response);
 
 		$request = new Request('http://example.com', 'GET');
 		$request = $request->withHeader('testHeader', '');
 
-		$this->assertEquals(
-			'ReturnString',
+		$this->assertSame(
+			$response,
 			$this->object->sendRequest($request)
 		);
 	}

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": "~7.0",
         "joomla/uri": "~1.0|~2.0",
         "composer/ca-bundle": "~1.0",
+        "psr/http-client": "~0.3",
         "psr/http-message": "~1.0",
         "zendframework/zend-diactoros": "~1.1"
     },

--- a/src/Exception/InvalidResponseCodeException.php
+++ b/src/Exception/InvalidResponseCodeException.php
@@ -8,11 +8,13 @@
 
 namespace Joomla\Http\Exception;
 
+use Psr\Http\Client\ClientExceptionInterface;
+
 /**
  * Exception representing an invalid or undefined HTTP response code
  *
  * @since  1.2.0
  */
-class InvalidResponseCodeException extends \UnexpectedValueException
+class InvalidResponseCodeException extends \UnexpectedValueException implements ClientExceptionInterface
 {
 }

--- a/src/Exception/UnexpectedResponseException.php
+++ b/src/Exception/UnexpectedResponseException.php
@@ -9,13 +9,14 @@
 namespace Joomla\Http\Exception;
 
 use Joomla\Http\Response;
+use Psr\Http\Client\ClientExceptionInterface;
 
 /**
  * Exception representing an unexpected response
  *
  * @since  1.2.0
  */
-class UnexpectedResponseException extends \DomainException
+class UnexpectedResponseException extends \DomainException implements ClientExceptionInterface
 {
 	/**
 	 * The Response object.

--- a/src/Http.php
+++ b/src/Http.php
@@ -10,14 +10,16 @@ namespace Joomla\Http;
 
 use Joomla\Uri\Uri;
 use Joomla\Uri\UriInterface;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * HTTP client class.
  *
  * @since  1.0
  */
-class Http
+class Http implements ClientInterface
 {
 	/**
 	 * Options for the HTTP client.
@@ -63,7 +65,7 @@ class Http
 			// Ensure the transport is a TransportInterface instance or bail out
 			if (!($transport instanceof TransportInterface))
 			{
-				throw new \InvalidArgumentException('A valid TransportInterface object was not set.');
+				throw new \InvalidArgumentException(sprintf('A valid %s object was not set.', TransportInterface::class));
 			}
 		}
 
@@ -235,15 +237,15 @@ class Http
 	}
 
 	/**
-	 * Send a request to a remote server based on a PSR-7 RequestInterface object.
+	 * Sends a PSR-7 request and returns a PSR-7 response.
 	 *
 	 * @param   RequestInterface  $request  The PSR-7 request object.
 	 *
-	 * @return  Response
+	 * @return  ResponseInterface|Response
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function sendRequest(RequestInterface $request)
+	public function sendRequest(RequestInterface $request): ResponseInterface
 	{
 		$data = $request->getBody()->getContents();
 
@@ -300,7 +302,13 @@ class Http
 		}
 		elseif (!($url instanceof UriInterface))
 		{
-			throw new \InvalidArgumentException(sprintf('A string or UriInterface object must be provided, a "%s" was provided.', \gettype($url)));
+			throw new \InvalidArgumentException(
+				sprintf(
+					'A string or %s object must be provided, a "%s" was provided.',
+					UriInterface::class,
+					\gettype($url)
+				)
+			);
 		}
 
 		return $this->transport->request($method, $url, $data, $headers, $timeout, $userAgent);


### PR DESCRIPTION
### Summary of Changes

Since the PSR-18 vote has basically passed, this makes the `Http` class implement `Psr\Http\Client\ClientInterface` and our custom exceptions implement `Psr\Http\Client\ClientExceptionInterface`.  The basic change needed was making the `sendRequest` method typehint the return type, and since this is only added on the 2.0 branch there's no B/C issue with that.

Note that for now this does NOT make the full package PSR-18 compliant; most of our exceptions are still core PHP exceptions and we need to add more exception subclasses for the other error types implementing `Psr\Http\Client\ClientExceptionInterface` for full minimal compliance (we really should be implementing `Psr\Http\Client\NetworkExceptionInterface` and `Psr\Http\Client\RequestExceptionInterface` in our exceptions but those require a `Psr\Http\Message\RequestInterface` object and our transports are not prepared to receive a PSR-7 Request object right now).

The other "significant" change in this PR is just changing the exception about an invalid param for the URI to use the FQCN instead of the shortened `UriInterface`.