### PR TITLE
Don't add Host-Header in Socket-Transport if it's already mentioned on headers

### DIFF
--- a/src/Transport/Socket.php
+++ b/src/Transport/Socket.php
@@ -124,7 +124,11 @@ class Socket implements TransportInterface
 		// Build the request payload.
 		$request   = array();
 		$request[] = strtoupper($method) . ' ' . ((empty($path)) ? '/' : $path) . ' HTTP/' . $protocolVersion;
-		$request[] = 'Host: ' . $uri->getHost();
+
+		if (!isset($headers['Host']))
+		{
+			$request[] = 'Host: ' . $uri->getHost();
+		}
 
 		// If an explicit user agent is given use it.
 		if (isset($userAgent))


### PR DESCRIPTION
When using Socket-Transport Host-Header might be send twice if it was already mentioned on Headers for the request. This might confuse Apache's mod_ssl and returns a 421-Error, this leads to situations where e.g. HTTPS cannot be enabled on Joomla's backend.

### Summary of Changes
Test if Host-Header is not set before adding a static Host-Header

### Testing Instructions
Disable all other Transports and try fetch a HTTPS-Resource from a mod_ssl-powered Apache httpd.

### Documentation Changes Required
None.