### PR TITLE
[1.x] Phase out deprecated `$php_errormsg` variable and `track_errors` use

### DIFF
--- a/src/Transport/Socket.php
+++ b/src/Transport/Socket.php
@@ -42,18 +42,16 @@ class Socket implements TransportInterface
 	 *
 	 * @param   array|\ArrayAccess  $options  Client options array.
 	 *
-	 * @since   1.0
 	 * @throws  \RuntimeException
+	 * @since   1.0
 	 */
 	public function __construct($options = array())
 	{
-		if (!self::isSupported())
-		{
+		if (!self::isSupported()) {
 			throw new \RuntimeException('Cannot use a socket transport when fsockopen() is not available.');
 		}
 
-		if (!\is_array($options) && !($options instanceof \ArrayAccess))
-		{
+		if (!\is_array($options) && !($options instanceof \ArrayAccess)) {
 			throw new \InvalidArgumentException(
 				'The options param must be an array or implement the ArrayAccess interface.'
 			);
@@ -74,26 +72,28 @@ class Socket implements TransportInterface
 	 *
 	 * @return  Response
 	 *
-	 * @since   1.0
 	 * @throws  \RuntimeException
+	 * @since   1.0
 	 */
-	public function request($method, UriInterface $uri, $data = null, array $headers = null, $timeout = null, $userAgent = null)
-	{
+	public function request(
+		$method,
+		UriInterface $uri,
+		$data = null,
+		array $headers = null,
+		$timeout = null,
+		$userAgent = null
+	) {
 		$connection = $this->connect($uri, $timeout);
 
 		// Make sure the connection is alive and valid.
-		if (\is_resource($connection))
-		{
+		if (\is_resource($connection)) {
 			// Make sure the connection has not timed out.
 			$meta = stream_get_meta_data($connection);
 
-			if ($meta['timed_out'])
-			{
+			if ($meta['timed_out']) {
 				throw new \RuntimeException('Server connection timed out.');
 			}
-		}
-		else
-		{
+		} else {
 			throw new \RuntimeException('Not connected to server.');
 		}
 
@@ -101,16 +101,13 @@ class Socket implements TransportInterface
 		$path = $uri->toString(array('path', 'query'));
 
 		// If we have data to send make sure our request is setup for it.
-		if (!empty($data))
-		{
+		if (!empty($data)) {
 			// If the data is not a scalar value encode it to be sent with the request.
-			if (!is_scalar($data))
-			{
+			if (!is_scalar($data)) {
 				$data = http_build_query($data);
 			}
 
-			if (!isset($headers['Content-Type']))
-			{
+			if (!isset($headers['Content-Type'])) {
 				$headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
 			}
 
@@ -125,51 +122,44 @@ class Socket implements TransportInterface
 		$request   = array();
 		$request[] = strtoupper($method) . ' ' . ((empty($path)) ? '/' : $path) . ' HTTP/' . $protocolVersion;
 
-		if (!isset($headers['Host']))
-		{
+		if (!isset($headers['Host'])) {
 			$request[] = 'Host: ' . $uri->getHost();
 		}
 
 		// If an explicit user agent is given use it.
-		if (isset($userAgent))
-		{
+		if (isset($userAgent)) {
 			$headers['User-Agent'] = $userAgent;
 		}
 
 		// If we have a username then we include basic authentication credentials.
-		if ($uri->getUser())
-		{
+		if ($uri->getUser()) {
 			$authString               = $uri->getUser() . ':' . $uri->getPass();
 			$headers['Authorization'] = 'Basic ' . base64_encode($authString);
 		}
 
 		// If there are custom headers to send add them to the request payload.
-		if (\is_array($headers))
-		{
-			foreach ($headers as $k => $v)
-			{
+		if (\is_array($headers)) {
+			foreach ($headers as $k => $v) {
 				$request[] = $k . ': ' . $v;
 			}
 		}
 
 		// Authentication, if needed
-		if (isset($this->options['userauth'], $this->options['passwordauth']))
-		{
-			$request[] = 'Authorization: Basic ' . base64_encode($this->options['userauth'] . ':' . $this->options['passwordauth']);
+		if (isset($this->options['userauth'], $this->options['passwordauth'])) {
+			$request[] = 'Authorization: Basic ' . base64_encode(
+					$this->options['userauth'] . ':' . $this->options['passwordauth']
+				);
 		}
 
 		// Set any custom transport options
-		if (isset($this->options['transport.socket']))
-		{
-			foreach ($this->options['transport.socket'] as $value)
-			{
+		if (isset($this->options['transport.socket'])) {
+			foreach ($this->options['transport.socket'] as $value) {
 				$request[] = $value;
 			}
 		}
 
 		// If we have data to send add it to the request payload.
-		if (!empty($data))
-		{
+		if (!empty($data)) {
 			$request[] = null;
 			$request[] = $data;
 		}
@@ -180,17 +170,22 @@ class Socket implements TransportInterface
 		// Get the response data from the server.
 		$content = '';
 
-		while (!feof($connection))
-		{
+		while (!feof($connection)) {
 			$content .= fgets($connection, 4096);
 		}
 
 		$content = $this->getResponse($content);
 
 		// Follow Http redirects
-		if ($content->code >= 301 && $content->code < 400 && isset($content->headers['Location']))
-		{
-			return $this->request($method, new Uri($content->headers['Location']), $data, $headers, $timeout, $userAgent);
+		if ($content->code >= 301 && $content->code < 400 && isset($content->headers['Location'])) {
+			return $this->request(
+				$method,
+				new Uri($content->headers['Location']),
+				$data,
+				$headers,
+				$timeout,
+				$userAgent
+			);
 		}
 
 		return $content;
@@ -203,17 +198,16 @@ class Socket implements TransportInterface
 	 *
 	 * @return  Response
 	 *
-	 * @since   1.0
 	 * @throws  \UnexpectedValueException
 	 * @throws  InvalidResponseCodeException
+	 * @since   1.0
 	 */
 	protected function getResponse($content)
 	{
 		// Create the response object.
 		$return = new Response;
 
-		if (empty($content))
-		{
+		if (empty($content)) {
 			throw new \UnexpectedValueException('No content in response.');
 		}
 
@@ -230,19 +224,15 @@ class Socket implements TransportInterface
 		preg_match('/[0-9]{3}/', array_shift($headers), $matches);
 		$code = $matches[0];
 
-		if (is_numeric($code))
-		{
-			$return->code = (int) $code;
-		}
-		else
-		{
+		if (is_numeric($code)) {
+			$return->code = (int)$code;
+		} else {
 			// No valid response code was detected.
 			throw new InvalidResponseCodeException('No HTTP response code found.');
 		}
 
 		// Add the response headers to the response object.
-		foreach ($headers as $header)
-		{
+		foreach ($headers as $header) {
 			$pos                                             = strpos($header, ':');
 			$return->headers[trim(substr($header, 0, $pos))] = trim(substr($header, ($pos + 1)));
 		}
@@ -258,8 +248,8 @@ class Socket implements TransportInterface
 	 *
 	 * @return  resource  Socket connection resource.
 	 *
-	 * @since   1.0
 	 * @throws  \RuntimeException
+	 * @since   1.0
 	 */
 	protected function connect(UriInterface $uri, $timeout = null)
 	{
@@ -270,14 +260,10 @@ class Socket implements TransportInterface
 		$host = ($uri->isSsl()) ? 'ssl://' . $uri->getHost() : $uri->getHost();
 
 		// If the port is not explicitly set in the URI detect it.
-		if (!$uri->getPort())
-		{
+		if (!$uri->getPort()) {
 			$port = ($uri->getScheme() == 'https') ? 443 : 80;
-		}
-
-		// Use the set port.
-		else
-		{
+		} // Use the set port.
+		else {
 			$port = $uri->getPort();
 		}
 
@@ -285,64 +271,61 @@ class Socket implements TransportInterface
 		$key = md5($host . $port);
 
 		// If the connection already exists, use it.
-		if (!empty($this->connections[$key]) && \is_resource($this->connections[$key]))
-		{
+		if (!empty($this->connections[$key]) && \is_resource($this->connections[$key])) {
 			// Connection reached EOF, cannot be used anymore
 			$meta = stream_get_meta_data($this->connections[$key]);
 
-			if ($meta['eof'])
-			{
-				if (!fclose($this->connections[$key]))
-				{
+			if ($meta['eof']) {
+				if (!fclose($this->connections[$key])) {
 					throw new \RuntimeException('Cannot close connection');
 				}
-			}
-
-			// Make sure the connection has not timed out.
-			elseif (!$meta['timed_out'])
-			{
+			} // Make sure the connection has not timed out.
+			elseif (!$meta['timed_out']) {
 				return $this->connections[$key];
 			}
 		}
 
-		if (!is_numeric($timeout))
-		{
+		if (!is_numeric($timeout)) {
 			$timeout = ini_get('default_socket_timeout');
 		}
 
 		// Capture PHP errors
-		$php_errormsg = '';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
 
 		// PHP sends a warning if the uri does not exists; we silence it and throw an exception instead.
 		// Attempt to connect to the server
 		$connection = @fsockopen($host, $port, $errno, $err, $timeout);
 
-		if (!$connection)
-		{
-			if (!$php_errormsg)
-			{
+		if (!$connection) {
+			$error = error_get_last();
+			if ($error === null || $error['message'] === '') {
 				// Error but nothing from php? Create our own
-				$php_errormsg = sprintf('Could not connect to resource: %s', $uri, $err, $errno);
+				$error = array(
+					'message' => sprintf('Could not connect to resource %s: %s (%d)', $uri, $err, $errno)
+				);
 			}
 
-			// Restore error tracking to give control to the exception handler
-			ini_set('track_errors', $trackErrors);
-
-			throw new \RuntimeException($php_errormsg);
+			throw new \RuntimeException($error['message']);
 		}
-
-		// Restore error tracking to what it was before.
-		ini_set('track_errors', $trackErrors);
 
 		// Since the connection was successful let's store it in case we need to use it later.
 		$this->connections[$key] = $connection;
 
 		// If an explicit timeout is set, set it.
-		if (isset($timeout))
-		{
-			stream_set_timeout($this->connections[$key], (int) $timeout);
+		if (isset($timeout)) {
+			stream_set_timeout($this->connections[$key], (int)$timeout);
 		}
 
 		return $this->connections[$key];

--- a/src/Transport/Socket.php
+++ b/src/Transport/Socket.php
@@ -42,8 +42,8 @@ class Socket implements TransportInterface
 	 *
 	 * @param   array|\ArrayAccess  $options  Client options array.
 	 *
-	 * @throws  \RuntimeException
 	 * @since   1.0
+	 * @throws  \RuntimeException
 	 */
 	public function __construct($options = array())
 	{
@@ -74,17 +74,11 @@ class Socket implements TransportInterface
 	 *
 	 * @return  Response
 	 *
-	 * @throws  \RuntimeException
 	 * @since   1.0
+	 * @throws  \RuntimeException
 	 */
-	public function request(
-		$method,
-		UriInterface $uri,
-		$data = null,
-		array $headers = null,
-		$timeout = null,
-		$userAgent = null
-	) {
+	public function request($method, UriInterface $uri, $data = null, array $headers = null, $timeout = null, $userAgent = null)
+	{
 		$connection = $this->connect($uri, $timeout);
 
 		// Make sure the connection is alive and valid.
@@ -161,9 +155,7 @@ class Socket implements TransportInterface
 		// Authentication, if needed
 		if (isset($this->options['userauth'], $this->options['passwordauth']))
 		{
-			$request[] = 'Authorization: Basic ' . base64_encode(
-					$this->options['userauth'] . ':' . $this->options['passwordauth']
-				);
+			$request[] = 'Authorization: Basic ' . base64_encode($this->options['userauth'] . ':' . $this->options['passwordauth']);
 		}
 
 		// Set any custom transport options
@@ -198,14 +190,7 @@ class Socket implements TransportInterface
 		// Follow Http redirects
 		if ($content->code >= 301 && $content->code < 400 && isset($content->headers['Location']))
 		{
-			return $this->request(
-				$method,
-				new Uri($content->headers['Location']),
-				$data,
-				$headers,
-				$timeout,
-				$userAgent
-			);
+			return $this->request($method, new Uri($content->headers['Location']), $data, $headers, $timeout, $userAgent);
 		}
 
 		return $content;
@@ -218,9 +203,9 @@ class Socket implements TransportInterface
 	 *
 	 * @return  Response
 	 *
+	 * @since   1.0
 	 * @throws  \UnexpectedValueException
 	 * @throws  InvalidResponseCodeException
-	 * @since   1.0
 	 */
 	protected function getResponse($content)
 	{
@@ -273,8 +258,8 @@ class Socket implements TransportInterface
 	 *
 	 * @return  resource  Socket connection resource.
 	 *
-	 * @throws  \RuntimeException
 	 * @since   1.0
+	 * @throws  \RuntimeException
 	 */
 	protected function connect(UriInterface $uri, $timeout = null)
 	{
@@ -288,7 +273,9 @@ class Socket implements TransportInterface
 		if (!$uri->getPort())
 		{
 			$port = ($uri->getScheme() == 'https') ? 443 : 80;
-		} // Use the set port.
+		}
+
+		// Use the set port.
 		else
 		{
 			$port = $uri->getPort();
@@ -309,7 +296,9 @@ class Socket implements TransportInterface
 				{
 					throw new \RuntimeException('Cannot close connection');
 				}
-			} // Make sure the connection has not timed out.
+			}
+
+			// Make sure the connection has not timed out.
 			elseif (!$meta['timed_out'])
 			{
 				return $this->connections[$key];

--- a/src/Transport/Socket.php
+++ b/src/Transport/Socket.php
@@ -47,11 +47,13 @@ class Socket implements TransportInterface
 	 */
 	public function __construct($options = array())
 	{
-		if (!self::isSupported()) {
+		if (!self::isSupported())
+		{
 			throw new \RuntimeException('Cannot use a socket transport when fsockopen() is not available.');
 		}
 
-		if (!\is_array($options) && !($options instanceof \ArrayAccess)) {
+		if (!\is_array($options) && !($options instanceof \ArrayAccess))
+		{
 			throw new \InvalidArgumentException(
 				'The options param must be an array or implement the ArrayAccess interface.'
 			);
@@ -86,14 +88,18 @@ class Socket implements TransportInterface
 		$connection = $this->connect($uri, $timeout);
 
 		// Make sure the connection is alive and valid.
-		if (\is_resource($connection)) {
+		if (\is_resource($connection))
+		{
 			// Make sure the connection has not timed out.
 			$meta = stream_get_meta_data($connection);
 
-			if ($meta['timed_out']) {
+			if ($meta['timed_out'])
+			{
 				throw new \RuntimeException('Server connection timed out.');
 			}
-		} else {
+		}
+		else
+		{
 			throw new \RuntimeException('Not connected to server.');
 		}
 
@@ -101,13 +107,16 @@ class Socket implements TransportInterface
 		$path = $uri->toString(array('path', 'query'));
 
 		// If we have data to send make sure our request is setup for it.
-		if (!empty($data)) {
+		if (!empty($data))
+		{
 			// If the data is not a scalar value encode it to be sent with the request.
-			if (!is_scalar($data)) {
+			if (!is_scalar($data))
+			{
 				$data = http_build_query($data);
 			}
 
-			if (!isset($headers['Content-Type'])) {
+			if (!isset($headers['Content-Type']))
+			{
 				$headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
 			}
 
@@ -122,44 +131,53 @@ class Socket implements TransportInterface
 		$request   = array();
 		$request[] = strtoupper($method) . ' ' . ((empty($path)) ? '/' : $path) . ' HTTP/' . $protocolVersion;
 
-		if (!isset($headers['Host'])) {
+		if (!isset($headers['Host']))
+		{
 			$request[] = 'Host: ' . $uri->getHost();
 		}
 
 		// If an explicit user agent is given use it.
-		if (isset($userAgent)) {
+		if (isset($userAgent))
+		{
 			$headers['User-Agent'] = $userAgent;
 		}
 
 		// If we have a username then we include basic authentication credentials.
-		if ($uri->getUser()) {
+		if ($uri->getUser())
+		{
 			$authString               = $uri->getUser() . ':' . $uri->getPass();
 			$headers['Authorization'] = 'Basic ' . base64_encode($authString);
 		}
 
 		// If there are custom headers to send add them to the request payload.
-		if (\is_array($headers)) {
-			foreach ($headers as $k => $v) {
+		if (\is_array($headers))
+		{
+			foreach ($headers as $k => $v)
+			{
 				$request[] = $k . ': ' . $v;
 			}
 		}
 
 		// Authentication, if needed
-		if (isset($this->options['userauth'], $this->options['passwordauth'])) {
+		if (isset($this->options['userauth'], $this->options['passwordauth']))
+		{
 			$request[] = 'Authorization: Basic ' . base64_encode(
 					$this->options['userauth'] . ':' . $this->options['passwordauth']
 				);
 		}
 
 		// Set any custom transport options
-		if (isset($this->options['transport.socket'])) {
-			foreach ($this->options['transport.socket'] as $value) {
+		if (isset($this->options['transport.socket']))
+		{
+			foreach ($this->options['transport.socket'] as $value)
+			{
 				$request[] = $value;
 			}
 		}
 
 		// If we have data to send add it to the request payload.
-		if (!empty($data)) {
+		if (!empty($data))
+		{
 			$request[] = null;
 			$request[] = $data;
 		}
@@ -170,14 +188,16 @@ class Socket implements TransportInterface
 		// Get the response data from the server.
 		$content = '';
 
-		while (!feof($connection)) {
+		while (!feof($connection))
+		{
 			$content .= fgets($connection, 4096);
 		}
 
 		$content = $this->getResponse($content);
 
 		// Follow Http redirects
-		if ($content->code >= 301 && $content->code < 400 && isset($content->headers['Location'])) {
+		if ($content->code >= 301 && $content->code < 400 && isset($content->headers['Location']))
+		{
 			return $this->request(
 				$method,
 				new Uri($content->headers['Location']),
@@ -207,7 +227,8 @@ class Socket implements TransportInterface
 		// Create the response object.
 		$return = new Response;
 
-		if (empty($content)) {
+		if (empty($content))
+		{
 			throw new \UnexpectedValueException('No content in response.');
 		}
 
@@ -224,15 +245,19 @@ class Socket implements TransportInterface
 		preg_match('/[0-9]{3}/', array_shift($headers), $matches);
 		$code = $matches[0];
 
-		if (is_numeric($code)) {
+		if (is_numeric($code))
+		{
 			$return->code = (int)$code;
-		} else {
+		}
+		else
+		{
 			// No valid response code was detected.
 			throw new InvalidResponseCodeException('No HTTP response code found.');
 		}
 
 		// Add the response headers to the response object.
-		foreach ($headers as $header) {
+		foreach ($headers as $header)
+		{
 			$pos                                             = strpos($header, ':');
 			$return->headers[trim(substr($header, 0, $pos))] = trim(substr($header, ($pos + 1)));
 		}
@@ -260,10 +285,12 @@ class Socket implements TransportInterface
 		$host = ($uri->isSsl()) ? 'ssl://' . $uri->getHost() : $uri->getHost();
 
 		// If the port is not explicitly set in the URI detect it.
-		if (!$uri->getPort()) {
+		if (!$uri->getPort())
+		{
 			$port = ($uri->getScheme() == 'https') ? 443 : 80;
 		} // Use the set port.
-		else {
+		else
+		{
 			$port = $uri->getPort();
 		}
 
@@ -271,27 +298,33 @@ class Socket implements TransportInterface
 		$key = md5($host . $port);
 
 		// If the connection already exists, use it.
-		if (!empty($this->connections[$key]) && \is_resource($this->connections[$key])) {
+		if (!empty($this->connections[$key]) && \is_resource($this->connections[$key]))
+		{
 			// Connection reached EOF, cannot be used anymore
 			$meta = stream_get_meta_data($this->connections[$key]);
 
-			if ($meta['eof']) {
-				if (!fclose($this->connections[$key])) {
+			if ($meta['eof'])
+			{
+				if (!fclose($this->connections[$key]))
+				{
 					throw new \RuntimeException('Cannot close connection');
 				}
 			} // Make sure the connection has not timed out.
-			elseif (!$meta['timed_out']) {
+			elseif (!$meta['timed_out'])
+			{
 				return $this->connections[$key];
 			}
 		}
 
-		if (!is_numeric($timeout)) {
+		if (!is_numeric($timeout))
+		{
 			$timeout = ini_get('default_socket_timeout');
 		}
 
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
-			// @Todo Remove this path, when PHP5 support is dropped. 
+		if (PHP_VERSION_ID < 70000)
+		{
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -299,7 +332,9 @@ class Socket implements TransportInterface
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -308,9 +343,11 @@ class Socket implements TransportInterface
 		// Attempt to connect to the server
 		$connection = @fsockopen($host, $port, $errno, $err, $timeout);
 
-		if (!$connection) {
+		if (!$connection)
+		{
 			$error = error_get_last();
-			if ($error === null || $error['message'] === '') {
+			if ($error === null || $error['message'] === '')
+			{
 				// Error but nothing from php? Create our own
 				$error = array(
 					'message' => sprintf('Could not connect to resource %s: %s (%d)', $uri, $err, $errno)
@@ -324,7 +361,8 @@ class Socket implements TransportInterface
 		$this->connections[$key] = $connection;
 
 		// If an explicit timeout is set, set it.
-		if (isset($timeout)) {
+		if (isset($timeout))
+		{
 			stream_set_timeout($this->connections[$key], (int)$timeout);
 		}
 

--- a/src/Transport/Stream.php
+++ b/src/Transport/Stream.php
@@ -211,8 +211,9 @@ class Stream implements TransportInterface
 		$context = stream_context_create($streamOptions);
 
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
-			// @Todo Remove this path, when PHP5 support is dropped. 
+		if (PHP_VERSION_ID < 70000)
+		{
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -220,7 +221,9 @@ class Stream implements TransportInterface
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -231,7 +234,8 @@ class Stream implements TransportInterface
 		if (!$stream)
 		{
 			$error = error_get_last();
-			if ($error === null || $error['message'] === '') {
+			if ($error === null || $error['message'] === '')
+			{
 				// Error but nothing from php? Create our own
 				$error = array(
 					'message' => sprintf('Could not connect to resource %s', $uri)


### PR DESCRIPTION
### Summary of Changes

PHP 7.2 deprecates the track_errors INI configuration and the scoped $php_errormsg variable in favor of using the error_get_last() function for retrieving error data, and at PHP 7.0 using error_clear_last() to clear any errors (to my knowledge we aren't doing anything in core requiring the latter at the moment).

This PR phases out this deprecated functionality.

### Testing Instructions

The packages should still function normally, including error handling (easiest way to test error handling is enable debug mode and language debug and break one of the language files with a parsing error).
