### PR TITLE
[1.x] http request header

### DIFF
--- a/src/Transport/Socket.php
+++ b/src/Transport/Socket.php
@@ -119,7 +119,7 @@ class Socket implements TransportInterface
 		}
 
 		// Configure protocol version, use transport's default if not set otherwise.
-		$protocolVersion = isset($this->options['protocolVersion']) ? $this->options['protocolVersion'] : '1.0';
+		$protocolVersion = isset($this->options['protocolVersion']) ? $this->options['protocolVersion'] : '1.1';
 
 		// Build the request payload.
 		$request   = array();


### PR DESCRIPTION
code review

Mozilla telemetry indicates that there is less than 0.24% still using 1.0 https://mzl.la/3tFMtkA

httparchive didnt even include 1.0 in its 2020 almanac https://almanac.httparchive.org/en/2020/http#fig-3 but in 2019 they reported less than 0.06%

Also see https://github.com/joomla/joomla-cms/pull/35568