### PR TITLE
feat: Add support for non-blocking mode in Stream Transport

### DIFF
--- a/src/Transport/Stream.php
+++ b/src/Transport/Stream.php
@@ -105,8 +105,8 @@ class Stream extends AbstractTransport
             // If authentication details are provided, add those as well
             if ($this->getOption('proxy.user') && $this->getOption('proxy.password')) {
                 $headers['Proxy-Authorization'] = 'Basic ' . base64_encode(
-                        $this->getOption('proxy.user') . ':' . $this->getOption('proxy.password')
-                    );
+                    $this->getOption('proxy.user') . ':' . $this->getOption('proxy.password')
+                );
             }
         }
 

--- a/src/Transport/Stream.php
+++ b/src/Transport/Stream.php
@@ -17,6 +17,8 @@ use Joomla\Uri\Uri;
 use Joomla\Uri\UriInterface;
 use Laminas\Diactoros\Stream as StreamResponse;
 
+use function stream_set_blocking;
+
 /**
  * HTTP transport class for using PHP streams.
  *
@@ -36,11 +38,17 @@ class Stream extends AbstractTransport
      *
      * @return  Response
      *
-     * @since   1.0
      * @throws  \RuntimeException
+     * @since   1.0
      */
-    public function request($method, UriInterface $uri, $data = null, array $headers = [], $timeout = null, $userAgent = null)
-    {
+    public function request(
+        $method,
+        UriInterface $uri,
+        $data = null,
+        array $headers = [],
+        $timeout = null,
+        $userAgent = null
+    ) {
         // Create the stream context options array with the required method offset.
         $options = ['method' => strtoupper($method)];
 
@@ -64,7 +72,7 @@ class Stream extends AbstractTransport
 
         // If an explicit timeout is given user it.
         if (isset($timeout)) {
-            $options['timeout'] = (int) $timeout;
+            $options['timeout'] = (int)$timeout;
         }
 
         // If an explicit user agent is given use it.
@@ -76,7 +84,7 @@ class Stream extends AbstractTransport
         $options['ignore_errors'] = 1;
 
         // Follow redirects.
-        $options['follow_location'] = (int) $this->getOption('follow_location', 1);
+        $options['follow_location'] = (int)$this->getOption('follow_location', 1);
 
         // Configure protocol version, use transport's default if not set otherwise.
         $options['protocol_version'] = $this->getOption('protocolVersion', '1.0');
@@ -91,12 +99,14 @@ class Stream extends AbstractTransport
             $options['request_fulluri'] = true;
 
             if ($this->getOption('proxy.host') && $this->getOption('proxy.port')) {
-                $options['proxy'] = $this->getOption('proxy.host') . ':' . (int) $this->getOption('proxy.port');
+                $options['proxy'] = $this->getOption('proxy.host') . ':' . (int)$this->getOption('proxy.port');
             }
 
             // If authentication details are provided, add those as well
             if ($this->getOption('proxy.user') && $this->getOption('proxy.password')) {
-                $headers['Proxy-Authorization'] = 'Basic ' . base64_encode($this->getOption('proxy.user') . ':' . $this->getOption('proxy.password'));
+                $headers['Proxy-Authorization'] = 'Basic ' . base64_encode(
+                        $this->getOption('proxy.user') . ':' . $this->getOption('proxy.password')
+                    );
             }
         }
 
@@ -133,7 +143,10 @@ class Stream extends AbstractTransport
         $contextOptions = stream_context_get_options(stream_context_get_default());
 
         // Add our options to the currently defined options, if any.
-        $contextOptions['http'] = isset($contextOptions['http']) ? array_merge($contextOptions['http'], $options) : $options;
+        $contextOptions['http'] = isset($contextOptions['http']) ? array_merge(
+            $contextOptions['http'],
+            $options
+        ) : $options;
 
         // Create the stream context for the request.
         $streamOptions = [
@@ -160,7 +173,7 @@ class Stream extends AbstractTransport
         error_clear_last();
 
         // Open the stream for reading.
-        $stream = @fopen((string) $uri, 'r', false, $context);
+        $stream = @fopen((string)$uri, 'r', false, $context);
 
         if (!$stream) {
             $error = error_get_last();
@@ -174,6 +187,16 @@ class Stream extends AbstractTransport
 
             throw new \RuntimeException($error['message']);
         }
+
+        /**
+         * Add stream_set_blocking option to support non-blocking mode
+         * Default set to true to keep previous behaviour.
+         * Set to false to enable non-blocking mode
+         *
+         * @see https://www.php.net/manual/en/function.stream-set-blocking.php
+         */
+        $enableBlockingMode = isset($options['set_blocking']) ? $options['set_blocking'] : true;
+        stream_set_blocking($stream, $enableBlockingMode);
 
         // Get the metadata for the stream, including response headers.
         $metadata = stream_get_meta_data($stream);
@@ -203,8 +226,8 @@ class Stream extends AbstractTransport
      *
      * @return  Response
      *
-     * @since   1.0
      * @throws  InvalidResponseCodeException
+     * @since   1.0
      */
     protected function getResponse(array $headers, $body)
     {
@@ -217,7 +240,7 @@ class Stream extends AbstractTransport
             throw new InvalidResponseCodeException('No HTTP response code found.');
         }
 
-        $statusCode      = (int) $code;
+        $statusCode = (int)$code;
         $verifiedHeaders = $this->processHeaders($headers);
 
         $streamInterface = new StreamResponse('php://memory', 'rw');


### PR DESCRIPTION
Non-Blocking mode is only relevant for OPTION,HEAD,GET request since it only affects reading from the stream reference: https://www.php.net/manual/en/function.stream-set-blocking.php

Pull Request for Issue # none. I was told once by a Joomla maintainer to not post an issue if we can do directly a pull request. Hence I don't do it anymore if I can propose a change with actual code.

### Summary of Changes
>Add possible to support non-blocking mode by supplying set_blocking option in 
transport.stream

> Basically this pull request just adds
``` stream_set_blocking($stream, $enableBlockingMode); ```

### Testing Instructions
I also added Unit Tests to make sure it doesn't break current code.
You only need to run the unit tests instructions already provided in the repository

### Documentation Changes Required
Not really. But might be good to make people aware of this new feature in our beloved joomla/http package.
