### PR TITLE
[PHP8.4] Deprecate implicitly nullable parameter types

### DIFF
--- a/src/Exception/UnexpectedResponseException.php
+++ b/src/Exception/UnexpectedResponseException.php
@@ -37,7 +37,7 @@ class UnexpectedResponseException extends \DomainException implements ClientExce
      *
      * @since   1.2.0
      */
-    public function __construct(Response $response, $message = '', $code = 0, \Exception $previous = null)
+    public function __construct(Response $response, $message = '', $code = 0, ?\Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Http.php
+++ b/src/Http.php
@@ -48,7 +48,7 @@ class Http implements ClientInterface
      * @since   1.0
      * @throws  \InvalidArgumentException
      */
-    public function __construct($options = [], TransportInterface $transport = null)
+    public function __construct($options = [], ?TransportInterface $transport = null)
     {
         if (!\is_array($options) && !($options instanceof \ArrayAccess)) {
             throw new \InvalidArgumentException(


### PR DESCRIPTION
### Summary of Changes

updates for [Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

### Testing Instructions

code review

### Documentation Changes Required

no