### PR TITLE
[3.x][PHP8.5] curl_close() function has been deprecated

### DIFF
--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -181,9 +181,6 @@ class Curl extends AbstractTransport
         // Get the request information.
         $info = curl_getinfo($ch);
 
-        // Close the connection.
-        curl_close($ch);
-
         return $this->getResponse($content, $info);
     }
 


### PR DESCRIPTION
### Summary of Changes

remove no longer needed `curl_close()`

> In the migration of various extensions from resources to objects, a number of functions to close or free the resources became no-ops
> curl_close() since the ext/curl migration in PHP 8.0

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_curl_close

### Testing Instructions

Run unit tests `./vendor/bin/phpunit`
- enable max error reporting
- use php 8.5 (latest pre-version 8.5.0rc2)

### Documentation Changes Required

no