### PR TITLE
Remove redundant CA option call

### DIFF
--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -69,9 +69,6 @@ class Curl extends AbstractTransport
         // Don't wait for body when $method is HEAD
         $options[\CURLOPT_NOBODY] = ($method === 'HEAD');
 
-        // Initialize the certificate store
-        $options[CURLOPT_CAINFO] = $this->getOption('curl.certpath', CaBundle::getSystemCaRootBundlePath());
-
         // If data exists let's encode it and make sure our Content-type header is set.
         if (isset($data)) {
             // If the data is a scalar value simply add it to the cURL post fields.


### PR DESCRIPTION
### Summary of Changes
In order to properly use HTTPS connections, a valid and up-to-date CA file is needed. That can either be a single file or a directory holding multiple files. 

In our CURL transport, a protected method `setCAOptionAndValue` fetches the correct file OR folder and sets the respective CURL option.

However, a redundant call in the request method tried to do the same, however without checking if the return from CaBundle is a path and not a file.

On systems where CaBundle returns a path, the following error message is shown while fetching extension updates wiht debug mode on:

`An error has occurred: error setting certificate file: /PATH/TO/CERTS `

### Testing Instructions
Code Review

### Documentation Changes Required
