### PR TITLE
Set default userAgent if nothing else is set (redo CMS http package)

### DIFF
--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -41,7 +41,6 @@ class HttpFactory
             $options['userAgent'] = 'Mozilla/5.0 Joomla!/Framework';
         }
 
-
         if (!$driver = $this->getAvailableDriver($options, $adapters)) {
             throw new \RuntimeException('No transport driver available.');
         }

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -38,8 +38,7 @@ class HttpFactory
 
         // Set default userAgent if nothing else is set
         if (!isset($options['userAgent'])) {
-            $version              = new Version();
-            $options['userAgent'] = $version->getUserAgent('Joomla', true, false);
+            $options['userAgent'] = 'Mozilla/5.0 Joomla!';
         }
 
 

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -36,6 +36,13 @@ class HttpFactory
             );
         }
 
+        // Set default userAgent if nothing else is set
+        if (!isset($options['userAgent'])) {
+            $version              = new Version();
+            $options['userAgent'] = $version->getUserAgent('Joomla', true, false);
+        }
+
+
         if (!$driver = $this->getAvailableDriver($options, $adapters)) {
             throw new \RuntimeException('No transport driver available.');
         }

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -38,7 +38,7 @@ class HttpFactory
 
         // Set default userAgent if nothing else is set
         if (!isset($options['userAgent'])) {
-            $options['userAgent'] = 'Mozilla/5.0 Joomla!';
+            $options['userAgent'] = 'Mozilla/5.0 Joomla!/Framework';
         }
 
 


### PR DESCRIPTION
Set default userAgent if nothing else is set, as it is in Joomla CMS http package.

The change introduces in https://github.com/joomla/joomla-cms/pull/45751 to replace CMS Http package by the framework package with the PSR-7 interface has some difference.

The missing part to set userAgent as default if nothing else set will return a 403 error when trying to update an extension, if the update xml file is hosted on a server using a firewall.

This missing part (difference with CMS http package) in Joomla 6.0+ blocked updates for one of my update server xml hosted on OVH where their firewall was enabled. Disabling the hosting server firewall was the only way to make the update process works.

The userAgent check was introduced in this PR: https://github.com/joomla/joomla-cms/pull/16538
That fixes the issue of a missing userAgent for extensions updates.

